### PR TITLE
feat: Implement Notion database selection and conditions UI for templ…

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -53,7 +53,7 @@
     {
       "name": "string (必須, テンプレートの管理名)",
       "notionDatabaseId": "string (必須, 通知のトリガーとなる Notion データベースの ID)",
-      "userNotionIntegrationId": "string (必須, このテンプレートが使用する User Notion Integration の ID)",
+      "useruserNotionIntegrationId": "string (必須, このテンプレートが使用する User Notion Integration の ID)",
       "body": "string (必須, 通知メッセージの本文。プレースホルダ使用可)",
       "conditions": [
         {
@@ -73,7 +73,7 @@
           "id": "string (自動生成されたテンプレート ID)",
           "name": "string",
           "notionDatabaseId": "string",
-          "userNotionIntegrationId": "string | null (テンプレートが使用する User Notion Integration の ID)",
+          "useruserNotionIntegrationId": "string | null (テンプレートが使用する User Notion Integration の ID)",
           "body": "string",
           "conditions": [ /* ... */ ],
           "destinationId": "string",
@@ -154,7 +154,7 @@
     {
       "name": "string (オプション)",
       "notionDatabaseId": "string (オプション)",
-      "userNotionIntegrationId": "string | null (オプション, このテンプレートが使用する User Notion Integration の ID。null を指定すると連携解除)",
+      "useruserNotionIntegrationId": "string | null (オプション, このテンプレートが使用する User Notion Integration の ID。null を指定すると連携解除)",
       "body": "string (オプション)",
       "conditions": [ /* ... */ ],
       "destinationId": "string (オプション)"
@@ -170,7 +170,7 @@
     curl -X PUT http://localhost:3000/api/v1/templates/your_template_id_here \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer YOUR_ID_TOKEN_HERE" \
-     -d '{"name": "更新後のテンプレート名", "body": "更新されたメッセージ本文！", "userNotionIntegrationId": "new_integration_id"}'
+     -d '{"name": "更新後のテンプレート名", "body": "更新されたメッセージ本文！", "useruserNotionIntegrationId": "new_integration_id"}'
     ```
 
 ### 1.5. テンプレートの削除

--- a/src/app/(authenticated)/templates/[id]/edit/page.tsx
+++ b/src/app/(authenticated)/templates/[id]/edit/page.tsx
@@ -35,14 +35,14 @@ import type { Destination } from "@/types/destination";
 
 const formSchema = z.object({
 	name: z.string().min(1, { message: "Template name is required." }),
-	notionIntegrationId: z.string().min(1, { message: "Notion integration is required." }),
+	userNotionIntegrationId: z.string().min(1, { message: "Notion integration is required." }),
 	notionDatabaseId: z.string().min(1, { message: "Notion Database ID is required." }),
 	conditions: z.array(z.object({ // Added
 		propertyId: z.string().min(1, "Property selection is required."),
 		operator: z.string().min(1, "Operator selection is required."),
 		value: z.string().min(1, "Value is required."),
 	})).optional(),
-	messageBody: z.string().min(1, { message: "Message body is required." }),
+	body: z.string().min(1, { message: "Message body is required." }),
 	destinationId: z.string().min(1, { message: "Destination is required." }),
 });
 
@@ -68,10 +68,10 @@ function EditTemplatePage() {
 		defaultValues: {
 			// Added default values
 			name: "",
-			notionIntegrationId: "",
+			userNotionIntegrationId: "",
 			notionDatabaseId: "",
 			conditions: [], // Added
-			messageBody: "",
+			body: "",
 			destinationId: "",
 		},
 	});
@@ -106,7 +106,7 @@ function EditTemplatePage() {
 		}
 	);
 
-	const selectedNotionIntegrationId = watch("notionIntegrationId");
+	const selecteduserNotionIntegrationId = watch("userNotionIntegrationId");
 	const selectedNotionDatabaseId = watch("notionDatabaseId"); // Added
 
 	const {
@@ -114,14 +114,14 @@ function EditTemplatePage() {
 		isLoading: isLoadingNotionDatabases,
 		error: errorNotionDatabases,
 	} = useQuery<NotionDatabase[], Error>({
-		queryKey: ["notionDatabases", selectedNotionIntegrationId],
+		queryKey: ["notionDatabases", selecteduserNotionIntegrationId],
 		queryFn: () => {
-			if (!selectedNotionIntegrationId) {
+			if (!selecteduserNotionIntegrationId) {
 				return Promise.resolve([]);
 			}
-			return getNotionDatabases(selectedNotionIntegrationId);
+			return getNotionDatabases(selecteduserNotionIntegrationId);
 		},
-		enabled: !!selectedNotionIntegrationId,
+		enabled: !!selecteduserNotionIntegrationId,
 	});
 
 	const { // Added Db Properties Query
@@ -129,17 +129,17 @@ function EditTemplatePage() {
 		isLoading: isLoadingDbProperties,
 		error: errorDbProperties,
 	} = useQuery<NotionProperty[], Error>({
-		queryKey: ["databaseProperties", selectedNotionIntegrationId, selectedNotionDatabaseId],
-		queryFn: () => getNotionDatabaseProperties(selectedNotionIntegrationId as string, selectedNotionDatabaseId as string),
-		enabled: !!selectedNotionIntegrationId && !!selectedNotionDatabaseId && !isLoadingTemplate, // Ensure template is loaded
+		queryKey: ["databaseProperties", selecteduserNotionIntegrationId, selectedNotionDatabaseId],
+		queryFn: () => getNotionDatabaseProperties(selecteduserNotionIntegrationId as string, selectedNotionDatabaseId as string),
+		enabled: !!selecteduserNotionIntegrationId && !!selectedNotionDatabaseId && !isLoadingTemplate, // Ensure template is loaded
 	});
 
 	useEffect(() => {
-		if (template && selectedNotionIntegrationId && selectedNotionIntegrationId !== template.notionIntegrationId) {
+		if (template && selecteduserNotionIntegrationId && selecteduserNotionIntegrationId !== template.userNotionIntegrationId) {
 			setValue("notionDatabaseId", "", { shouldValidate: true });
 			setValue("conditions", [], { shouldValidate: false }); // Added: Clear conditions
 		}
-	}, [selectedNotionIntegrationId, setValue, template]);
+	}, [selecteduserNotionIntegrationId, setValue, template]);
 
 	useEffect(() => { // Added: Clear conditions if database changes from original template
 		if (template && selectedNotionDatabaseId && selectedNotionDatabaseId !== template.notionDatabaseId) {
@@ -151,10 +151,10 @@ function EditTemplatePage() {
 		if (template) {
 			reset({
 				name: template.name,
-				notionIntegrationId: template.notionIntegrationId,
+				userNotionIntegrationId: template.userNotionIntegrationId,
 				notionDatabaseId: template.notionDatabaseId,
 				conditions: template.conditions || [], // Updated: handle conditions
-				messageBody: template.messageBody,
+				body: template.body,
 				destinationId: template.destinationId,
 			});
 			// `replace` from useFieldArray can also be used here if `reset` doesn't work as expected for field arrays
@@ -244,9 +244,9 @@ function EditTemplatePage() {
 						</div>
 
 						<div className="space-y-2">
-							<Label htmlFor="notionIntegrationId">Use Notion Integration</Label>
+							<Label htmlFor="userNotionIntegrationId">Use Notion Integration</Label>
 							<Controller
-								name="notionIntegrationId"
+								name="userNotionIntegrationId"
 								control={control}
 								render={({ field }) => (
 									<Select
@@ -276,9 +276,9 @@ function EditTemplatePage() {
 									</Select>
 								)}
 							/>
-							{errors.notionIntegrationId && (
+							{errors.userNotionIntegrationId && (
 								<p className="text-red-600 text-sm">
-									{errors.notionIntegrationId.message}
+									{errors.userNotionIntegrationId.message}
 								</p>
 							)}
 						</div>
@@ -295,7 +295,7 @@ function EditTemplatePage() {
 										}}
 										value={field.value} // Ensures the value is controlled by RHF
 										disabled={
-											!selectedNotionIntegrationId ||
+											!selecteduserNotionIntegrationId ||
 											isLoadingNotionDatabases ||
 											mutation.isPending ||
 											isLoadingTemplate // Disable if template still loading integration ID
@@ -304,7 +304,7 @@ function EditTemplatePage() {
 										<SelectTrigger>
 											<SelectValue
 												placeholder={
-													!selectedNotionIntegrationId
+													!selecteduserNotionIntegrationId
 														? "Select a Notion Integration first"
 														: "Select a Notion Database"
 												}
@@ -321,7 +321,7 @@ function EditTemplatePage() {
 												</SelectItem>
 											) : !isLoadingNotionDatabases &&
 											  notionDatabases &&
-											  notionDatabases.length === 0 && selectedNotionIntegrationId ? (
+											  notionDatabases.length === 0 && selecteduserNotionIntegrationId ? (
 												<SelectItem value="no_db" disabled>
 													No databases found for this integration.
 												</SelectItem>
@@ -332,7 +332,7 @@ function EditTemplatePage() {
 													</SelectItem>
 												))
 											)}
-											{!selectedNotionIntegrationId && !isLoadingNotionDatabases && (
+											{!selecteduserNotionIntegrationId && !isLoadingNotionDatabases && (
 												<SelectItem value="select_integration_first" disabled>
 													Select a Notion Integration first
 												</SelectItem>
@@ -384,7 +384,7 @@ function EditTemplatePage() {
 						{fields.map((field, index) => (
 							<div key={field.id} className="flex items-start space-x-2 p-2 border rounded-md">
 								<div className="flex-1 space-y-2">
-									<div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+									<div className="gap-2 grid grid-cols-1 md:grid-cols-3">
 										{/* Property Select */}
 										<div className="space-y-1">
 											<Label htmlFor={`conditions.${index}.propertyId`}>Property</Label>
@@ -474,7 +474,7 @@ function EditTemplatePage() {
 									disabled={mutation.isPending || isLoadingTemplate}
 									className="mt-6" // Adjust margin to align with form fields
 								>
-									<Trash2 className="h-4 w-4" />
+									<Trash2 className="w-4 h-4" />
 								</Button>
 							</div>
 						))}
@@ -505,10 +505,10 @@ function EditTemplatePage() {
 						<CardTitle>3. Notification Message</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-2">
-						<Label htmlFor="messageBody">Message Body</Label>
-						<Textarea id="messageBody" rows={5} {...register("messageBody")} />
-						{errors.messageBody && (
-							<p className="text-red-600 text-sm">{errors.messageBody.message}</p>
+						<Label htmlFor="body">Message Body</Label>
+						<Textarea id="body" rows={5} {...register("body")} />
+						{errors.body && (
+							<p className="text-red-600 text-sm">{errors.body.message}</p>
 						)}
 						<p className="text-muted-foreground text-xs">
 							Placeholders like {"{PropertyName}"} (e.g. {"{Task Name}"}) and{" "}

--- a/src/app/(authenticated)/templates/new/page.tsx
+++ b/src/app/(authenticated)/templates/new/page.tsx
@@ -41,14 +41,14 @@ import type { Destination } from "@/types/destination";
 
 const formSchema = z.object({
 	name: z.string().min(1, { message: "Template name is required." }),
-	notionIntegrationId: z.string().min(1, { message: "Notion integration is required." }),
+	userNotionIntegrationId: z.string().min(1, { message: "Notion integration is required." }),
 	notionDatabaseId: z.string().min(1, { message: "Notion Database ID is required." }),
 	conditions: z.array(z.object({ // Added
 		propertyId: z.string().min(1, "Property selection is required."),
 		operator: z.string().min(1, "Operator selection is required."),
 		value: z.string().min(1, "Value is required."), 
 	})).optional(),
-	messageBody: z.string().min(1, { message: "Message body is required." }),
+	body: z.string().min(1, { message: "Message body is required." }),
 	destinationId: z.string().min(1, { message: "Destination is required." }),
 });
 
@@ -70,10 +70,10 @@ function NewTemplatePage() {
 		resolver: zodResolver(formSchema),
 		defaultValues: {
 			name: "",
-			notionIntegrationId: "",
+			userNotionIntegrationId: "",
 			notionDatabaseId: "",
 			conditions: [], // Updated
-			messageBody: "",
+			body: "",
 			destinationId: "",
 		},
 	});
@@ -98,7 +98,7 @@ function NewTemplatePage() {
 		}
 	);
 
-	const selectedNotionIntegrationId = watch("notionIntegrationId");
+	const selecteduserNotionIntegrationId = watch("userNotionIntegrationId");
 	const selectedNotionDatabaseId = watch("notionDatabaseId"); // Added
 
 	const {
@@ -106,14 +106,14 @@ function NewTemplatePage() {
 		isLoading: isLoadingNotionDatabases,
 		error: errorNotionDatabases,
 	} = useQuery<NotionDatabase[], Error>({
-		queryKey: ["notionDatabases", selectedNotionIntegrationId],
+		queryKey: ["notionDatabases", selecteduserNotionIntegrationId],
 		queryFn: () => {
-			if (!selectedNotionIntegrationId) {
+			if (!selecteduserNotionIntegrationId) {
 				return Promise.resolve([]); // Or handle as appropriate
 			}
-			return getNotionDatabases(selectedNotionIntegrationId);
+			return getNotionDatabases(selecteduserNotionIntegrationId);
 		},
-		enabled: !!selectedNotionIntegrationId,
+		enabled: !!selecteduserNotionIntegrationId,
 	});
 
 	const { // Added Db Properties Query
@@ -121,17 +121,17 @@ function NewTemplatePage() {
 		isLoading: isLoadingDbProperties,
 		error: errorDbProperties,
 	} = useQuery<NotionProperty[], Error>({
-		queryKey: ["databaseProperties",selectedNotionIntegrationId, selectedNotionDatabaseId],
-		queryFn: () => getNotionDatabaseProperties(selectedNotionIntegrationId as string, selectedNotionDatabaseId as string),
-		enabled: !!selectedNotionIntegrationId && !!selectedNotionDatabaseId,
+		queryKey: ["databaseProperties",selecteduserNotionIntegrationId, selectedNotionDatabaseId],
+		queryFn: () => getNotionDatabaseProperties(selecteduserNotionIntegrationId as string, selectedNotionDatabaseId as string),
+		enabled: !!selecteduserNotionIntegrationId && !!selectedNotionDatabaseId,
 	});
 
 	useEffect(() => {
-		if (selectedNotionIntegrationId) {
+		if (selecteduserNotionIntegrationId) {
 			setValue("notionDatabaseId", "", { shouldValidate: true });
 			setValue("conditions", [], { shouldValidate: false }); // Added
 		}
-	}, [selectedNotionIntegrationId, setValue]);
+	}, [selecteduserNotionIntegrationId, setValue]);
 
 	useEffect(() => { // Added
 		if (selectedNotionDatabaseId) {
@@ -190,9 +190,9 @@ function NewTemplatePage() {
 						</div>
 
 						<div className="space-y-2">
-							<Label htmlFor="notionIntegrationId">Use Notion Integration</Label>
+							<Label htmlFor="userNotionIntegrationId">Use Notion Integration</Label>
 							<Controller
-								name="notionIntegrationId"
+								name="userNotionIntegrationId"
 								control={control}
 								render={({ field }) => (
 									<Select
@@ -222,9 +222,9 @@ function NewTemplatePage() {
 									</Select>
 								)}
 							/>
-							{errors.notionIntegrationId && (
+							{errors.userNotionIntegrationId && (
 								<p className="text-red-600 text-sm">
-									{errors.notionIntegrationId.message}
+									{errors.userNotionIntegrationId.message}
 								</p>
 							)}
 						</div>
@@ -239,7 +239,7 @@ function NewTemplatePage() {
 										onValueChange={field.onChange}
 										value={field.value}
 										disabled={
-											!selectedNotionIntegrationId ||
+											!selecteduserNotionIntegrationId ||
 											isLoadingNotionDatabases ||
 											mutation.isPending
 										}
@@ -247,7 +247,7 @@ function NewTemplatePage() {
 										<SelectTrigger>
 											<SelectValue
 												placeholder={
-													!selectedNotionIntegrationId
+													!selecteduserNotionIntegrationId
 														? "Select a Notion Integration first"
 														: "Select a Notion Database"
 												}
@@ -322,7 +322,7 @@ function NewTemplatePage() {
 						{fields.map((field, index) => (
 							<div key={field.id} className="flex items-start space-x-2 p-2 border rounded-md">
 								<div className="flex-1 space-y-2">
-									<div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+									<div className="gap-2 grid grid-cols-1 md:grid-cols-3">
 										{/* Property Select */}
 										<div className="space-y-1">
 											<Label htmlFor={`conditions.${index}.propertyId`}>Property</Label>
@@ -412,7 +412,7 @@ function NewTemplatePage() {
 									disabled={mutation.isPending}
 									className="mt-6" // Adjust margin to align with form fields
 								>
-									<Trash2 className="h-4 w-4" />
+									<Trash2 className="w-4 h-4" />
 								</Button>
 							</div>
 						))}
@@ -443,15 +443,15 @@ function NewTemplatePage() {
 						<CardTitle>3. Notification Message</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-2">
-						<Label htmlFor="messageBody">Message Body</Label>
+						<Label htmlFor="body">Message Body</Label>
 						<Textarea
-							id="messageBody"
+							id="body"
 							placeholder="Type your notification message here..."
 							rows={5}
-							{...register("messageBody")}
+							{...register("body")}
 						/>
-						{errors.messageBody && (
-							<p className="text-red-600 text-sm">{errors.messageBody.message}</p>
+						{errors.body && (
+							<p className="text-red-600 text-sm">{errors.body.message}</p>
 						)}
 						<p className="text-muted-foreground text-xs">
 							Placeholders like {"{PropertyName}"} (e.g. {"{Task Name}"}) and{" "}

--- a/src/app/(authenticated)/templates/page.tsx
+++ b/src/app/(authenticated)/templates/page.tsx
@@ -159,7 +159,7 @@ function TemplatesDashboardPage() {
               <TableRow key={template.id}>
                 <TableCell>{template.name}</TableCell>
                 <TableCell>
-                  {notionIntegrationMap.get(template.notionIntegrationId) || template.notionIntegrationId}
+                  {notionIntegrationMap.get(template.userNotionIntegrationId) || template.userNotionIntegrationId}
                 </TableCell>
                 <TableCell>{template.notionDatabaseId}</TableCell>
                 <TableCell>
@@ -190,12 +190,12 @@ function TemplatesDashboardPage() {
           </TableBody>
         </Table>
       ) : (
-        <div className="text-center py-10">
-          <svg xmlns="http://www.w3.org/2000/svg" className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1">
+        <div className="py-10 text-center">
+          <svg xmlns="http://www.w3.org/2000/svg" className="mx-auto w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1">
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No notification templates found.</h3>
-          <p className="mt-1 text-sm text-gray-500">Get started by creating a new template.</p>
+          <h3 className="mt-2 font-medium text-gray-900 text-sm">No notification templates found.</h3>
+          <p className="mt-1 text-gray-500 text-sm">Get started by creating a new template.</p>
           <div className="mt-6">
             <Link href="/templates/new">
               <Button>New Template</Button>

--- a/src/services/notionService.ts
+++ b/src/services/notionService.ts
@@ -1,0 +1,34 @@
+import { fetchApiClient } from "../lib/apiClient";
+import { NotionDatabase, NotionProperty } from "../types/notionIntegration"; // Added NotionProperty
+
+export async function getNotionDatabases(integrationId: string): Promise<NotionDatabase[]> {
+  const response = await fetchApiClient(`/me/notion-integrations/${integrationId}/databases`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch Notion databases");
+  }
+
+  const data = await response.json();
+  return data as NotionDatabase[];
+}
+
+export async function getNotionDatabaseProperties(
+	integrationId: string,
+	databaseId: string
+): Promise<NotionProperty[]> {
+	const response = await fetchApiClient(
+		`/notion-databases/${databaseId}/properties?integrationId=${integrationId}`,
+		{
+			method: "GET",
+		}
+	);
+
+	if (!response.ok) {
+		throw new Error("Failed to fetch Notion database properties");
+	}
+
+	const data = await response.json();
+	return data as NotionProperty[];
+}

--- a/src/types/notionIntegration.ts
+++ b/src/types/notionIntegration.ts
@@ -6,3 +6,21 @@ export interface NotionIntegration {
   // e.g., workspace_name, workspace_icon, etc.
   // For now, keeping it simple as per the requirements.
 }
+
+export interface NotionDatabase {
+  id: string;
+  name: string;
+}
+
+export interface NotionPropertyOption {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface NotionProperty {
+  id: string;
+  name: string;
+  type: string;
+  options?: NotionPropertyOption[];
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -7,11 +7,11 @@ export interface TemplateCondition {
 export interface Template {
   id: string;
   name: string;
-  notionIntegrationId: string;
+  userNotionIntegrationId: string;
   destinationId: string;
   notionDatabaseId: string;
   conditions: TemplateCondition[]; // Updated type
-  messageBody: string;
+  body: string;
   updatedAt?: string; // Assuming this might come from the backend for "Last Updated"
   createdAt?: string;
 

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,10 +1,16 @@
+export interface TemplateCondition {
+  propertyId: string;
+  operator: string;
+  value: any; // Keeping as 'any' for now as per instruction
+}
+
 export interface Template {
   id: string;
   name: string;
   notionIntegrationId: string;
   destinationId: string;
   notionDatabaseId: string;
-  conditions: string | Record<string, any>; // Placeholder: string or simple object
+  conditions: TemplateCondition[]; // Updated type
   messageBody: string;
   updatedAt?: string; // Assuming this might come from the backend for "Last Updated"
   createdAt?: string;


### PR DESCRIPTION
…ates

This commit introduces two major features to the template creation and editing pages:

1.  **Notion Database Selection:**
    *   You can now select the target Notion database from a dropdown menu.
    *   The dropdown is populated dynamically by fetching databases accessible via the chosen Notion integration.
    *   Includes loading, error, and "no databases found" states for the dropdown.
    *   The selection of `notionDatabaseId` is reset if the Notion integration is changed.
    *   Relevant types (`NotionDatabase`) and service functions (`getNotionDatabases` in `notionService.ts`) were added.

2.  **Notification Conditions UI:**
    *   The placeholder textarea for notification conditions has been replaced with a dynamic interface.
    *   You can add multiple conditions, each consisting of a property, operator, and value.
    *   Database properties for the selected Notion database are fetched dynamically to populate the property selection dropdown.
    *   Includes loading, error, and "no properties found" states for property fetching.
    *   The `Template` type's `conditions` field has been updated to an array of structured condition objects (`TemplateCondition[]`).
    *   Form validation (Zod schema) and mutation payloads have been updated to support the new conditions structure.
    *   Relevant types (`NotionProperty`, `NotionPropertyOption`) and service functions (`getNotionDatabaseProperties` in `notionService.ts`) were added.

These changes address the requirements outlined in Part 1 and Part 2 of the issue statement for USR-010 and USR-011. Part 3 (Placeholder Assistance) is not yet implemented.